### PR TITLE
Add Homebridge UI config schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Supports triggering ssh commands on the HomeBridge platform.
 
 ## Configuration
 
+This plugin can be configured using the [Homebridge UI](https://github.com/homebridge/homebridge-config-ui-x). It exposes a configuration schema so the above settings can be entered through the graphical interface.
+
 Configuration sample:
 
 ```

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "pluginAlias": "SSH",
+  "pluginType": "accessory",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "title": "Name",
+        "type": "string",
+        "required": true
+      },
+      "on": {
+        "title": "On Command",
+        "type": "string",
+        "required": true
+      },
+      "off": {
+        "title": "Off Command",
+        "type": "string",
+        "required": true
+      },
+      "state": {
+        "title": "State Command",
+        "type": "string"
+      },
+      "on_value": {
+        "title": "On Value",
+        "type": "string",
+        "default": "playing"
+      },
+      "exact_match": {
+        "title": "Exact Match",
+        "type": "boolean",
+        "default": true
+      },
+      "ssh": {
+        "title": "SSH Settings",
+        "type": "object",
+        "properties": {
+          "host": {
+            "title": "Host",
+            "type": "string",
+            "required": true
+          },
+          "port": {
+            "title": "Port",
+            "type": "integer",
+            "default": 22
+          },
+          "user": {
+            "title": "Username",
+            "type": "string",
+            "required": true
+          },
+          "password": {
+            "title": "Password",
+            "type": "string"
+          },
+          "key": {
+            "title": "Private Key Path",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "additionalProperties": false
+  }
+}


### PR DESCRIPTION
## Summary
- add `config.schema.json` so SSH accessory can be configured through Homebridge UI
- document Homebridge UI support in README

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68abdef2ec4c832a96c14154c94c7e80